### PR TITLE
fix: add git pull --rebase before push in workflows

### DIFF
--- a/.github/workflows/daily-benchmark.yml
+++ b/.github/workflows/daily-benchmark.yml
@@ -233,6 +233,7 @@ jobs:
           git config --local user.name "GitHub Action"
           git add README.md previous-benchmark-results.json
           git commit -m "📊 Update benchmark results - $(date '+%Y-%m-%d') [${{ needs.analysis.outputs.tag-name }}]"
+          git pull --rebase origin main
           git push
 
       - name: Create or update GitHub release

--- a/.github/workflows/daily-updates.yml
+++ b/.github/workflows/daily-updates.yml
@@ -114,6 +114,7 @@ jobs:
           git config --local user.name "GitHub Action"
           git add -A
           git commit -m "⬆️ Update dependencies to latest versions - $(date '+%Y-%m-%d')" || exit 0
+          git pull --rebase origin main
           git push
 
       - name: Create PR for dependency updates


### PR DESCRIPTION
## What Changed

Added `git pull --rebase origin main` before `git push` in both GitHub Actions workflows:

- **daily-benchmark.yml**: Added rebase step before pushing benchmark results and README updates
- **daily-updates.yml**: Added rebase step before pushing dependency updates

## Why This Change

This prevents potential push conflicts in automated workflows when multiple commits are made to the main branch between the time the workflow starts and when it tries to push. The rebase ensures we have the latest changes before pushing.

## Changes Made

```diff
# In both workflows:
+ git pull --rebase origin main
  git push
```

This is a defensive programming practice that makes the workflows more robust against race conditions.